### PR TITLE
:bug: `q hello`ってやったときにhelloというコマンドとして認識されてしまっていたのを修正

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,8 +33,9 @@ func SetClient(c client.Client) {
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "q [message]",
-	Short: "traQ Webhook CLI",
+	TraverseChildren: true,
+	Use:              "q [message]",
+	Short:            "traQ Webhook CLI",
 	Long: `"q-cli" is a CLI tool for sending messages to traQ via webhook.
 It reads the configuration file and sends the message to the specified webhook.`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コマンドラインインターフェース（CLI）がサブコマンドをより柔軟に処理できるように、コマンド構造の変更を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->