### PR TITLE
チャンネルを指定できるようにする

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ var (
 
 var (
 	ErrEmptyConfiguration = errors.New("some webhook configuration field(s) is empty")
-	ErrChannelNotFound    = errors.New("channel is not found")
+	ErrChannelNotFound    = errors.New("channel name is not in the configuration")
 )
 
 func SetClient(c client.Client) {
@@ -113,7 +113,7 @@ It reads the configuration file and sends the message to the specified webhook.`
 			var ok bool
 			channelID, ok = conf.channels[channelName]
 			if !ok {
-				return fmt.Errorf("channel %s is not found: %w", channelName, ErrChannelNotFound)
+				return fmt.Errorf("channel '%s' is not found: %w", channelName, ErrChannelNotFound)
 			}
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/ikura-hamu/q-cli/internal/client"
 	"github.com/ikura-hamu/q-cli/internal/client/webhook"
 	"github.com/spf13/cobra"
@@ -96,7 +97,7 @@ It reads the configuration file and sends the message to the specified webhook.`
 		}
 
 		if cl != nil {
-			err := cl.SendMessage(message)
+			err := cl.SendMessage(message, uuid.Nil)
 			if errors.Is(err, client.ErrEmptyMessage) {
 				return errors.New("empty message is not allowed")
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/ikura-hamu/q-cli/internal/client"
 	"github.com/ikura-hamu/q-cli/internal/client/mock"
 	"github.com/spf13/viper"
@@ -68,7 +69,7 @@ func TestRoot(t *testing.T) {
 			w.Close()
 
 			mockClient := &mock.ClientMock{
-				SendMessageFunc: func(message string) error {
+				SendMessageFunc: func(message string, channelID uuid.UUID) error {
 					return tt.SendMessageErr
 				},
 			}
@@ -111,7 +112,7 @@ func TestRoot_NoSendMessage(t *testing.T) {
 			viper.Set("webhook_secret", tt.webhookSecret)
 
 			mockClient := &mock.ClientMock{
-				SendMessageFunc: func(message string) error {
+				SendMessageFunc: func(message string, channelID uuid.UUID) error {
 					return nil
 				},
 			}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,9 +1,11 @@
 package client
 
+import "github.com/google/uuid"
+
 //go:generate go run github.com/matryer/moq -pkg mock -out mock/${GOFILE}.go . Client
 
 type Client interface {
 	// SendMessage sends a message to the webhook URL
 	// if message is empty, it should return ErrEmptyMessage
-	SendMessage(message string) error
+	SendMessage(message string, channelID uuid.UUID) error
 }

--- a/internal/client/webhook/client.go
+++ b/internal/client/webhook/client.go
@@ -20,6 +20,10 @@ type WebhookClient struct {
 	webhookURL string
 }
 
+const (
+	channelIDHeader string = "X-TRAQ-Channel-ID"
+)
+
 func NewWebhookClient(webhookID string, hostName string, secret string) (*WebhookClient, error) {
 	mac := hmac.New(sha1.New, []byte(secret))
 
@@ -51,7 +55,7 @@ func (c *WebhookClient) SendMessage(message string, channelID uuid.UUID) error {
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
 
 	if channelID != uuid.Nil {
-		req.Header.Set("X-TRAQ-Channel-ID", channelID.String())
+		req.Header.Set(channelIDHeader, channelID.String())
 	}
 
 	c.mac.Reset()

--- a/internal/client/webhook/client.go
+++ b/internal/client/webhook/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/ikura-hamu/q-cli/internal/client"
 )
 
@@ -37,7 +38,7 @@ func NewWebhookClient(webhookID string, hostName string, secret string) (*Webhoo
 	}, nil
 }
 
-func (c *WebhookClient) SendMessage(message string) error {
+func (c *WebhookClient) SendMessage(message string, channelID uuid.UUID) error {
 	if message == "" {
 		return client.ErrEmptyMessage
 	}
@@ -48,6 +49,10 @@ func (c *WebhookClient) SendMessage(message string) error {
 	}
 
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+
+	if channelID != uuid.Nil {
+		req.Header.Set("X-TRAQ-Channel-ID", channelID.String())
+	}
 
 	c.mac.Reset()
 	_, err = c.mac.Write([]byte(message))

--- a/internal/client/webhook/client_test.go
+++ b/internal/client/webhook/client_test.go
@@ -21,7 +21,8 @@ func TestSendMessage(t *testing.T) {
 		wantErr   error
 	}{
 		"ok": {"test", uuid.Nil, false, nil},
-		"メッセージが空なのでエラー": {"", uuid.Nil, true, client.ErrEmptyMessage},
+		"チャンネルIDが指定されている": {"test", uuid.New(), false, nil},
+		"メッセージが空なのでエラー":   {"", uuid.Nil, true, client.ErrEmptyMessage},
 	}
 
 	for name, tc := range testCases {
@@ -38,6 +39,12 @@ func TestSendMessage(t *testing.T) {
 
 				assert.Equal(t, tc.message, mes)
 				assert.Equal(t, "/api/v3/webhooks/"+webhookID, path)
+
+				if tc.channelID != uuid.Nil {
+					assert.Equal(t, tc.channelID.String(), req.Header.Get(channelIDHeader))
+				} else {
+					assert.Empty(t, req.Header.Get(channelIDHeader))
+				}
 
 				res.WriteHeader(http.StatusNoContent)
 			}))

--- a/internal/client/webhook/client_test.go
+++ b/internal/client/webhook/client_test.go
@@ -6,51 +6,53 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/ikura-hamu/q-cli/internal/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSendMessage(t *testing.T) {
-	var (
-		mes  string
-		path string
-	)
-	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		b, err := io.ReadAll(req.Body)
-		require.NoError(t, err)
-		mes = string(b)
-		path = req.URL.Path
-
-		res.WriteHeader(http.StatusNoContent)
-	}))
-	defer ts.Close()
-
-	webhookID := "test"
-	cl, err := NewWebhookClient(webhookID, ts.URL, "test")
-	require.NoError(t, err)
 
 	testCases := map[string]struct {
-		message string
-		isError bool
-		wantErr error
+		message   string
+		channelID uuid.UUID
+		isError   bool
+		wantErr   error
 	}{
-		"ok": {"test", false, nil},
-		"メッセージが空なのでエラー": {"", true, client.ErrEmptyMessage},
+		"ok": {"test", uuid.Nil, false, nil},
+		"メッセージが空なのでエラー": {"", uuid.Nil, true, client.ErrEmptyMessage},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			// 共通のmesにリクエストボディを書き出しているので、t.Parallel()にはできない。
-			err := cl.SendMessage(tc.message)
+			t.Parallel()
+
+			webhookID := "test"
+
+			ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				b, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				mes := string(b)
+				path := req.URL.Path
+
+				assert.Equal(t, tc.message, mes)
+				assert.Equal(t, "/api/v3/webhooks/"+webhookID, path)
+
+				res.WriteHeader(http.StatusNoContent)
+			}))
+			defer ts.Close()
+
+			cl, err := NewWebhookClient(webhookID, ts.URL, "test")
+			require.NoError(t, err)
+
+			err = cl.SendMessage(tc.message, tc.channelID)
 
 			if tc.isError {
 				assert.ErrorIs(t, err, tc.wantErr)
 				return
 			}
 
-			assert.Equal(t, tc.message, mes)
-			assert.Equal(t, "/api/v3/webhooks/"+webhookID, path)
 		})
 	}
 }


### PR DESCRIPTION
fix: #6 

設定ファイルで

```yml
channels:
  name: uuid
```

みたいに書くと、

`q -C name`ってやったときにChannelIDが`uuid`のチャンネルに投稿できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 新しいコマンドラインフラグ `--channel` を追加し、メッセージ送信時にチャネル名を指定できるようになりました。
	- メッセージ送信機能にチャネルIDを追加し、指定されたチャネルにメッセージを送信できるようになりました。

- **バグ修正**
	- チャネル名が見つからない場合のエラーハンドリングを強化しました。

- **依存関係の更新**
	- UUIDを扱うための新しい依存関係 `github.com/google/uuid` を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->