### PR TITLE
flagまわりのリファクタリング

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -110,15 +111,12 @@ func TestRoot(t *testing.T) {
 			viper.Set("webhook_secret", tt.webhookConfig.secret)
 			viper.Set("channels", channelsStr)
 
-			withCodeBlock = tt.codeBlock
-			codeBlockLang = tt.codeBlockLang
-			channelName = tt.channelName
-
-			t.Cleanup(func() {
-				withCodeBlock = false
-				codeBlockLang = ""
-				channelName = ""
-			})
+			rootFlagsData := rootFlags{
+				codeBlock:     tt.codeBlock,
+				codeBlockLang: tt.codeBlockLang,
+				channelName:   tt.channelName,
+			}
+			rootCmd.SetContext(context.WithValue(context.Background(), rootFlagsCtxKey{}, &rootFlagsData))
 
 			r, w, err := os.Pipe()
 			require.NoError(t, err, "failed to create pipe")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -23,6 +23,7 @@ func TestRoot(t *testing.T) {
 		codeBlock     bool
 		codeBlockLang string
 		channelName   string
+		printVersion  bool
 		stdin         string
 		args          []string
 	}
@@ -33,67 +34,88 @@ func TestRoot(t *testing.T) {
 		SendMessageErr      error
 		expectedMessage     string
 		SkipCallSendMessage bool
-		expectedChannelID   uuid.UUID
-		isError             bool
-		expectedErr         error
+
+		expectedChannelID uuid.UUID
+		isError           bool
+		expectedErr       error
+		expectedStdout    string
 	}{
 		"ok": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{false, "", "", "", []string{"test"}},
+			input:             input{false, "", "", false, "", []string{"test"}},
 			expectedMessage:   "test",
 			expectedChannelID: uuid.Nil,
 		},
 		"コードブロックがあっても問題なし": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{true, "", "", "", []string{"print('Hello, World!')"}},
+			input:             input{true, "", "", false, "", []string{"print('Hello, World!')"}},
 			expectedMessage:   "```\nprint('Hello, World!')\n```",
 			expectedChannelID: uuid.Nil,
 		},
 		"コードブロックと言語指定があっても問題なし": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{true, "python", "", "", []string{"print('Hello, World!')"}},
+			input:             input{true, "python", "", false, "", []string{"print('Hello, World!')"}},
 			expectedMessage:   "```python\nprint('Hello, World!')\n```",
 			expectedChannelID: uuid.Nil,
 		},
 		"メッセージがない場合は標準入力から": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{false, "", "", "stdin test", nil},
+			input:             input{false, "", "", false, "stdin test", nil},
 			expectedMessage:   "stdin test",
 			expectedChannelID: uuid.Nil,
 		},
 		"メッセージがあったら標準入力は無視": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{false, "", "", "stdin test", []string{"test"}},
+			input:             input{false, "", "", false, "stdin test", []string{"test"}},
 			expectedMessage:   "test",
 			expectedChannelID: uuid.Nil,
 		},
 		"SendMessageがErrEmptyMessageを返す": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{false, "", "", "", nil},
+			input:             input{false, "", "", false, "", nil},
 			SendMessageErr:    client.ErrEmptyMessage,
 			expectedChannelID: uuid.Nil,
 			isError:           true,
 		},
 		"メッセージにコードブロックが含まれていて、そこにコードブロックを付けても問題なし": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{true, "", "", "```python\nprint('Hello, World!')\n```", nil},
+			input:             input{true, "", "", false, "```python\nprint('Hello, World!')\n```", nil},
 			expectedMessage:   "````\n```python\nprint('Hello, World!')\n```\n````",
 			expectedChannelID: uuid.Nil,
 		},
 		"チャンネル名を指定しても問題なし": {
 			webhookConfig:     defaultWebhookConfig,
-			input:             input{false, "", "channel", "test", nil},
+			input:             input{false, "", "channel", false, "test", nil},
 			expectedMessage:   "test",
 			expectedChannelID: channelID,
 		},
 		"チャンネル名が存在しない場合はエラー": {
 			webhookConfig:       defaultWebhookConfig,
-			input:               input{false, "", "notfound", "test", nil},
+			input:               input{false, "", "notfound", false, "test", nil},
 			SendMessageErr:      nil,
 			SkipCallSendMessage: true,
 			expectedChannelID:   uuid.Nil,
 			isError:             true,
 			expectedErr:         ErrChannelNotFound,
+		},
+		"print version": {
+			webhookConfig:       defaultWebhookConfig,
+			input:               input{false, "", "", true, "", nil},
+			SkipCallSendMessage: true,
+			expectedStdout:      "q version unknown\n",
+		},
+		"設定が不十分でもバージョンを表示": {
+			webhookConfig:       webhookConfig{},
+			input:               input{false, "", "", true, "", nil},
+			SkipCallSendMessage: true,
+			expectedStdout:      "q version unknown\n",
+		},
+		"設定が不十分なのでエラーメッセージ": {
+			webhookConfig:       webhookConfig{},
+			input:               input{false, "", "", false, "", nil},
+			SkipCallSendMessage: true,
+			isError:             true,
+			expectedErr:         ErrEmptyConfiguration,
 		},
 	}
 
@@ -118,19 +140,14 @@ func TestRoot(t *testing.T) {
 			}
 			rootCmd.SetContext(context.WithValue(context.Background(), rootFlagsCtxKey{}, &rootFlagsData))
 
-			r, w, err := os.Pipe()
-			require.NoError(t, err, "failed to create pipe")
+			printVersion = tt.printVersion
+			t.Cleanup(func() {
+				printVersion = false
+			})
 
-			origStdin := os.Stdin
-			os.Stdin = r
-			defer func() {
-				os.Stdin = origStdin
-				r.Close()
-			}()
+			stdinW := ReplaceStdin(t)
 
-			_, err = fmt.Fprint(w, tt.stdin)
-			require.NoError(t, err, "failed to write to pipe")
-			w.Close()
+			stdoutR := ReplaceStdout(t)
 
 			mockClient := &mock.ClientMock{
 				SendMessageFunc: func(message string, channelID uuid.UUID) error {
@@ -140,7 +157,12 @@ func TestRoot(t *testing.T) {
 
 			SetClient(mockClient)
 
+			_, err := fmt.Fprint(stdinW, tt.stdin)
+			require.NoError(t, err, "failed to write to pipe")
+			stdinW.Close()
+
 			cmdErr := rootCmd.RunE(rootCmd, tt.args)
+			os.Stdout.Close()
 
 			if tt.SkipCallSendMessage {
 				assert.Len(t, mockClient.SendMessageCalls(), 0)
@@ -149,6 +171,14 @@ func TestRoot(t *testing.T) {
 				assert.Len(t, mockClient.SendMessageCalls(), 1)
 				assert.Equal(t, tt.expectedMessage, mockClient.SendMessageCalls()[0].Message)
 				assert.Equal(t, tt.expectedChannelID, mockClient.SendMessageCalls()[0].ChannelID)
+			}
+
+			if tt.expectedStdout != "" {
+				var buffer bytes.Buffer
+				_, err := buffer.ReadFrom(stdoutR)
+				require.NoError(t, err, "failed to read from pipe")
+
+				assert.Equal(t, tt.expectedStdout, buffer.String())
 			}
 
 			if tt.isError {
@@ -164,59 +194,38 @@ func TestRoot(t *testing.T) {
 	}
 }
 
-func TestRoot_NoSendMessage(t *testing.T) {
-	test := map[string]struct {
-		webhookHost   string
-		webhookID     string
-		webhookSecret string
-		args          []string
-		printVersion  bool
-		wantStdout    string
-		wantErr       error
-	}{
-		"print version": {"http://localhost:8080", "test", "test", []string{}, true, "q version unknown\n", nil},
-		"設定が不十分でもversionをprint": {"", "test", "test", []string{}, true, "q version unknown\n", nil},
-		"設定が不十分なのでエラーメッセージ":     {"", "", "", []string{"aaa"}, false, "", ErrEmptyConfiguration},
-	}
+// 標準出力に書き込むとそれを読めるReaderを返す。
+// テスト対象の関数実行後、os.Stdoutをcloseすること。
+func ReplaceStdout(t *testing.T) *os.File {
+	t.Helper()
 
-	for description, tt := range test {
-		t.Run(description, func(t *testing.T) {
-			viper.Set("webhook_host", tt.webhookHost)
-			viper.Set("webhook_id", tt.webhookID)
-			viper.Set("webhook_secret", tt.webhookSecret)
+	stdoutR, stdoutW, err := os.Pipe()
+	require.NoError(t, err, "failed to create pipe")
 
-			mockClient := &mock.ClientMock{
-				SendMessageFunc: func(message string, channelID uuid.UUID) error {
-					return nil
-				},
-			}
+	origStdout := os.Stdout
+	os.Stdout = stdoutW
 
-			r, w, err := os.Pipe()
-			require.NoError(t, err, "failed to create pipe")
-			origStdout := os.Stdout
-			os.Stdout = w
-			defer func() {
-				os.Stdout = origStdout
-			}()
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+	})
 
-			printVersion = tt.printVersion
+	return stdoutR
+}
 
-			SetClient(mockClient)
+// 書き込むと標準入力に書き込まれるWriterを返す。
+func ReplaceStdin(t *testing.T) *os.File {
+	t.Helper()
 
-			cmdErr := rootCmd.RunE(rootCmd, []string{})
-			w.Close()
+	stdinR, stdinW, err := os.Pipe()
+	require.NoError(t, err, "failed to create pipe")
 
-			assert.Len(t, mockClient.SendMessageCalls(), 0)
-			var buffer bytes.Buffer
-			_, err = buffer.ReadFrom(r)
-			require.NoError(t, err, "failed to read from pipe")
+	origStdin := os.Stdin
+	os.Stdin = stdinR
 
-			assert.Equal(t, buffer.String(), tt.wantStdout)
-			if tt.wantErr != nil {
-				assert.ErrorIs(t, tt.wantErr, cmdErr)
-			} else {
-				assert.NoError(t, cmdErr)
-			}
-		})
-	}
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		stdinR.Close()
+	})
+
+	return stdinW
 }


### PR DESCRIPTION
- **:recycle: rootのフラグのグローバル変数をやめてcontextに渡す**
- **:recycle: rootのテストを1つにまとめる**

今までflagをグローバル変数で管理していたが、init関数の中でcontextに渡し、呼び出すときにcontextから取り出すようにした。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コマンドラインフラグの管理を簡素化するための新しい構造体 `rootFlags` を導入しました。
  - バージョン情報を表示するための新しいフラグ `printVersion` を追加し、関連するテストケースを強化しました。

- **バグ修正**
  - 不完全な構成時におけるバージョン情報の出力に関するエラーハンドリングを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->