### PR TITLE
:sparkles: configコマンド実装

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// configCmd represents the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "config prints the configuration file path and the current configuration of the CLI",
+	Long:  `configコマンドは、設定ファイルのパスと現在のCLIの設定を表示します。webhook_secretなど、一部の設定はマスクされます。`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fileName := viper.ConfigFileUsed()
+		allConfig := viper.AllSettings()
+
+		allConfig[configKeyWebhookSecret] = "********"
+
+		yamlConfig, err := yaml.Marshal(allConfig)
+		cobra.CheckErr(err)
+
+		fmt.Printf(`Config file used: %s
+
+%s
+`, fileName, string(yamlConfig))
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// configCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// configCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/go.mod
+++ b/go.mod
@@ -42,5 +42,5 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
fix: #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- CLIアプリケーションに`configCmd`コマンドを追加し、現在使用中の設定ファイルのパスと設定内容を表示します。セキュリティのため、`webhook_secret`の値はマスクされます。
- **依存関係の変更**
	- `go.mod`ファイル内の`gopkg.in/yaml.v3`の依存関係が間接依存から直接依存に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->